### PR TITLE
Add license information to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About gstreamer_and_plugins
 
 Home: 
 
-Package license: 
+Package license: LGPL-2.0-or-later
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/gstreamer-feedstock/blob/main/LICENSE.txt)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,6 +62,8 @@ outputs:
       summary: Library for constructing graphs of media-handling components
       description:
       doc_source_url: https://cgit.freedesktop.org/gstreamer/gstreamer/tree/docs
+      license: LGPL-2.0-or-later
+      license_file: COPYING
 
   - name: gst-plugins-base
     script: install_base_plugins.sh  # [unix]
@@ -143,6 +145,8 @@ outputs:
         GStreamer plug-ins and elements, spanning the range of possible types of
         elements one would want to write for GStreamer.
       doc_source_url: https://github.com/GStreamer/gst-plugins-base/tree/master/docs
+      license: LGPL-2.0-or-later
+      license_file: COPYING
 
   - name: gst-plugins-good
     script: install_good_plugins.sh  # [unix]
@@ -221,6 +225,8 @@ outputs:
         dressed up in tests.  If you're looking for a role model to
         base your own plug-in on here it is.
       doc_source_url: https://github.com/GStreamer/gst-plugins-good/tree/master/docs
+      license: LGPL-2.0-or-later
+      license_file: COPYING
 
 about:
   home: https://gstreamer.freedesktop.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
       - jpeg-win.patch  # [win]
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: gstreamer


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This should fix the problem of unspecified license here: https://anaconda.org/conda-forge/gstreamer