### PR TITLE
Revert "gstreamer v1.23.1 (#116)"

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,7 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
-MACOSX_SDK_VERSION:
-- '10.12'
 c_compiler:
 - clang
 c_compiler_version:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-MACOSX_SDK_VERSION:        # [osx and x86_64]
-  - "10.12"                # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.23.1" %}
+{% set version = "1.22.9" %}
 {% set posix = 'm2-' if win else '' %}
 
 package:
@@ -7,12 +7,12 @@ package:
 
 source:
   - url: https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-{{ version }}.tar.xz
-    sha256: 27fc189284b4c180846ac54dde1314ca01aabdaf1c4f115a3f54a9d158248bbb
+    sha256: 1e7124d347e8cdc80f08ec1d370c201be513002af1102bb20e83c5279cb48ebd
   - url: https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-{{ version }}.tar.xz
-    sha256: f6f1be3f47ff5ae895cfd372aa475fbbb1d83b9a829037b8764809cb218909eb
+    sha256: fac3e0dd2d8e9370388b34bf8c21b89d5f63bc3cfc12cd7fdc8fc6c1cba03334
     folder: plugins_base
   - url: https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-{{ version }}.tar.xz
-    sha256: e1c2eed6759c5897a67a778e8fa6a210863da05746da01fe07e508c72af6fa74
+    sha256: 26959fcfebfff637d4ea08ef40316baf31b61bb7729820b0684e800c3a1478b6
     folder: plugins_good
     patches:
       - jpeg-win.patch  # [win]


### PR DESCRIPTION
This reverts commit 5605dd27b4c577346225fca1d595dc38cc85b497, reversing changes made to b7fd7f2a7cfa4871dea2c0db7f58fb2819d0360c.


I don't want to rerender to avoid a build upload.

I checked that
- [x] Linux 64 same hash
- [x] OSX 64 same hash
- [x] Windows same hash

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
