### PR TITLE
Enable even_odd_versions in bot configuration

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -44,6 +44,8 @@ mpg123:
 - '1.32'
 openssl:
 - '3'
+pango:
+- '1'
 pulseaudio_client:
 - '17.0'
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -42,6 +42,8 @@ libxml2:
 - '2.13'
 openssl:
 - '3'
+pango:
+- '1'
 pulseaudio_client:
 - '17.0'
 target_platform:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -40,6 +40,8 @@ libxml2:
 - '2.13'
 openssl:
 - '3'
+pango:
+- '1'
 pulseaudio_client:
 - '17.0'
 target_platform:

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @yishai1999 @andfoy @ccordoba12 @hmaarrfk @mingwandroid @msarahan @scopatz @tschoonj
+* @andfoy @ccordoba12 @hmaarrfk @mingwandroid @msarahan @scopatz @tschoonj @yishai1999

--- a/README.md
+++ b/README.md
@@ -254,4 +254,5 @@ Feedstock Maintainers
 * [@msarahan](https://github.com/msarahan/)
 * [@scopatz](https://github.com/scopatz/)
 * [@tschoonj](https://github.com/tschoonj/)
+* [@yishai1999](https://github.com/yishai1999/)
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -14,3 +14,6 @@ provider:
   linux_aarch64: azure
   linux_ppc64le: azure
 test: native_and_emulated
+bot:
+  version_updates:
+    even_odd_versions: true


### PR DESCRIPTION
This PR enables the `even_odd_versions` setting in the bot section of conda-forge.yml to prevent automated updates to unstable versions.