### PR TITLE
gst-plugins-base: Build pango plugin on macOS

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     folder: plugins_good
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: gstreamer
@@ -111,7 +111,7 @@ outputs:
         - alsa-lib                           # [linux]
         - libopus                            # [unix]
         - libvorbis
-        - expat                              # [linux]
+        - expat                              # [unix]
         - xorg-libxfixes                     # [linux]
         - xorg-libxext                       # [linux]
         - xorg-xorgproto                     # [linux]
@@ -123,8 +123,8 @@ outputs:
         - xorg-libxshmfence                  # [linux]
         # July 17, 2025 -- yishai1999
         # https://github.com/conda-forge/gstreamer-feedstock/pull/155#discussion_r2213275624
-        # The GStreamer pango plugin doesn't seem to compile on OSX and windows
-        - pango                              # [linux]
+        # The GStreamer pango plugin doesn't seem to compile on windows
+        - pango                              # [unix]
       run:
         - {{ pin_subpackage('gstreamer', exact=True) }}
 
@@ -145,7 +145,7 @@ outputs:
         - if not exist %LIBRARY_BIN%\\gstallocators-1.0-0.dll exit 1  # [win]
         - if not exist %LIBRARY_LIB%\\girepository-1.0\\GstVideo-1.0.typelib exit 1  # [win]
         - gst-inspect-1.0 --plugin volume
-        - gst-inspect-1.0 --plugin pango  # [linux]
+        - gst-inspect-1.0 --plugin pango  # [unix]
 
     about:
       summary: GStreamer Base Plug-ins


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

In a [comment](https://github.com/conda-forge/gstreamer-feedstock/pull/155#discussion_r2213275624) to #155 there was mention of the pango plugins not building on macOS. Using the "changes" in this PR I was able to build and use the pango related plugins on a Mac with arm64 architecture running macOS 15.5.

I did not check if by now this also works on Windows and do not have a Windows machine to test that locally, so I adapted the dependencies and the comment in the code only for macOS. 

Update: Might be of relevance too: When only adding the pango dependency, there was indeed a build error pointing out that pkg-config could not find expat. So I added that on osx, too, and this solved the error.